### PR TITLE
👷 [+ci] Updating git tag during CI when template changes found

### DIFF
--- a/.github/actions/publish_impl/action.yml
+++ b/.github/actions/publish_impl/action.yml
@@ -1,0 +1,32 @@
+name: "[impl] Publish"
+description: "Publishes changes in this repository."
+
+runs:
+  using: composite
+  steps:
+    - name: Initialize
+      id: Initialize
+      uses: davidbrownell/dbrownell_DevTools/.github/actions/initialize@CI-v0.22.0
+      with:
+        operating_system: ${{ inputs.operating_system }}
+
+    - name: Bootstrap
+      shell: bash
+      run: |
+        ./Bootstrap.sh --python-version ${{ matrix.python_version }}
+
+    - name: Generate Version
+      id: version
+      shell: bash
+      run: |-
+        . ./Activate.sh
+        echo "template_version=$(autogitsemver ./template --quiet --no-branch-name --no-metadata)" >> $GITHUB_OUTPUT
+
+    - name: Create Tag
+      shell: bash
+      run: |
+        git config user.name "GitHub Action Bot"
+        git config user.email "<>"
+
+        git tag --annotate --force -m "Publish Tag" "v${{ steps.version.outputs.template_version }}" "${{ github.sha }}"
+        git push origin "v${{ steps.version.outputs.template_version }}" --force

--- a/.github/release_sources.yaml
+++ b/.github/release_sources.yaml
@@ -1,0 +1,3 @@
+# Changes to any of these files or a file within these directories will trigger a release.
+src:
+  - 'template/**'

--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
+  # ----------------------------------------------------------------------
   validate:
     name: Validate
     runs-on: ubuntu-latest
@@ -61,3 +62,31 @@ jobs:
         run: |
           . ./Activate.sh
           python Build.py pytest --verbose
+
+  # ----------------------------------------------------------------------
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+
+    needs: validate
+
+    permissions:
+      contents: write  # To tag the repository
+
+    steps:
+      - name: "Checkout Source"
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Has Release Changes?
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: dorny/paths-filter@v3
+        id: has_release_changes
+        with:
+          filters: .github/release_sources.yaml
+
+      - name: Publish
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.has_release_changes.outputs.src == 'true' }}
+        uses: ./.github/actions/publish_impl


### PR DESCRIPTION
## :pencil: Description
A git tag is created during the CI process when changes in the template directory are found. This is necessary because copier relies on these tags during the upgrade process.

## :gear: Work Item
https://dev.azure.com/gt-sse-center/Project%20Backlog/_workitems/edit/469

## :movie_camera: Demo
N/A