### PR TITLE
🐛 [-bug] Using author name in license rather than project name

### DIFF
--- a/template/__documentation/__licenses/Apache-2.0_LICENSE.txt
+++ b/template/__documentation/__licenses/Apache-2.0_LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright {{ '%Y' | strftime }} {{ project_name }}
+Copyright {{ '%Y' | strftime }} {{ author_name }}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/template/__documentation/__licenses/BSD-3-Clause-Clear_LICENSE.txt
+++ b/template/__documentation/__licenses/BSD-3-Clause-Clear_LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright {{ '%Y' | strftime }} {{ project_name }}
+Copyright {{ '%Y' | strftime }} {{ author_name }}
 
 Redistribution and use in source and binary forms, with or without
 modification are permitted provided that the following conditions are met:

--- a/template/__documentation/__licenses/BSL-1.0_LICENSE.txt
+++ b/template/__documentation/__licenses/BSL-1.0_LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright {{ '%Y' | strftime }} {{ project_name }}
+Copyright {{ '%Y' | strftime }} {{ author_name }}
 
 Boost Software License - Version 1.0 - August 17th, 2003
 

--- a/template/__documentation/__licenses/GPL-3.0-or-later_LICENSE.txt
+++ b/template/__documentation/__licenses/GPL-3.0-or-later_LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) {{ '%Y' | strftime }} {{ project_name }}
+Copyright (C) {{ '%Y' | strftime }} {{ author_name }}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/template/__documentation/__licenses/MIT_LICENSE.txt
+++ b/template/__documentation/__licenses/MIT_LICENSE.txt
@@ -1,6 +1,6 @@
 MIT LICENSE
 
-Copyright (c) {{ '%Y' | strftime }} {{ project_name }}
+Copyright (c) {{ '%Y' | strftime }} {{ author_name }}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/Documentation_EndToEndTest.py
+++ b/tests/Documentation_EndToEndTest.py
@@ -58,7 +58,7 @@ def test_License(license, copie, snapshot):
         Copyright           )Copyright\s+(?#
         Mark                )(?:\([cC]\)\s+)?(?#
         Year                ){datetime.now().year}\s+(?#
-        Project Name        ){configuration_info.configuration['project_name']}(?#
+        Project Name        ){configuration_info.configuration['author_name']}(?#
         End of line         )$(?#
         )""",
         Sub,

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -30151,7 +30151,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -30806,7 +30806,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -31593,7 +31593,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -32444,7 +32444,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -33128,7 +33128,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -33953,7 +33953,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -34912,7 +34912,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -35690,7 +35690,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -36609,7 +36609,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -38254,7 +38254,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -40041,7 +40041,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -41907,7 +41907,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -43726,7 +43726,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -45614,7 +45614,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -47455,7 +47455,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -49375,7 +49375,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -51248,7 +51248,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -53082,7 +53082,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -55219,7 +55219,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -57435,7 +57435,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -59604,7 +59604,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -61842,7 +61842,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -64033,7 +64033,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -66303,7 +66303,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -68526,7 +68526,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -70716,7 +70716,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -72564,7 +72564,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -74491,7 +74491,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -76371,7 +76371,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -78320,7 +78320,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -80222,7 +80222,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -82203,7 +82203,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -84137,7 +84137,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -86032,7 +86032,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -88230,7 +88230,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -90507,7 +90507,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -92737,7 +92737,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -95036,7 +95036,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -97288,7 +97288,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -99619,7 +99619,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal
@@ -101903,7 +101903,7 @@
     'LICENSE.txt': '''
       MIT LICENSE
       
-      Copyright (c) 2024 this_is_the_project_name
+      Copyright (c) 2024 <<author_name>>
       
       Permission is hereby granted, free of charge, to any person obtaining a copy
       of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## :pencil: Description
Fixed bug where the project name was used in a license file's copyright rather than the author name.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A
