### PR TITLE
👽️ [external_api_change] Using CI scripts that address breaking changes

### DIFF
--- a/.github/actions/publish_impl/action.yml
+++ b/.github/actions/publish_impl/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Initialize
       id: Initialize
-      uses: davidbrownell/dbrownell_DevTools/.github/actions/initialize@CI-v0.22.1
+      uses: davidbrownell/dbrownell_DevTools/.github/actions/initialize@CI-v0.23.0
       with:
         operating_system: ${{ inputs.operating_system }}
 

--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Initialize
         id: Initialize
-        uses: davidbrownell/dbrownell_DevTools/.github/actions/initialize@CI-v0.22.1
+        uses: davidbrownell/dbrownell_DevTools/.github/actions/initialize@CI-v0.23.0
         with:
           operating_system: ubuntu-latest
 

--- a/template/__project_type/__PythonPackage/{% if python_package_generate_ci %}.github{% endif %}/workflows/standard.yml
+++ b/template/__project_type/__PythonPackage/{% if python_package_generate_ci %}.github{% endif %}/workflows/standard.yml
@@ -19,7 +19,7 @@ jobs:
   # ----------------------------------------------------------------------
   action_contexts:
     name: "Display GitHub Action Contexts"
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
 
   # ----------------------------------------------------------------------
   validate:
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: read
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
 
     {%- if python_package_generate_ci_persist_coverage %}
     with:
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: read
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -122,7 +122,7 @@ jobs:
     permissions:
       contents: read
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -149,7 +149,7 @@ jobs:
     permissions:
       contents: read
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -175,7 +175,7 @@ jobs:
     permissions:
       contents: read
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
     with:
       operating_system: {% raw %}${{ matrix.os }}{% endraw %}
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -203,7 +203,7 @@ jobs:
       contents: read
       packages: write
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
     with:
       operating_system: ubuntu-latest
       python_version: {% raw %}${{ matrix.python_version }}{% endraw %}
@@ -230,7 +230,7 @@ jobs:
     permissions:
       contents: write
 
-    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+    uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
     with:
       release_sources_configuration_filename: .github/release_sources.yaml
     secrets:

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -5073,7 +5073,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -5098,7 +5098,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -5112,7 +5112,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -5138,7 +5138,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -5168,7 +5168,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -5186,7 +5186,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -6553,7 +6553,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -6578,7 +6578,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -6592,7 +6592,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -6618,7 +6618,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -6648,7 +6648,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -6666,7 +6666,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -8077,7 +8077,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -8102,7 +8102,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -8116,7 +8116,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -8142,7 +8142,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -8172,7 +8172,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -8200,7 +8200,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -8222,7 +8222,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -9589,7 +9589,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -9614,7 +9614,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -9628,7 +9628,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -9654,7 +9654,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -9684,7 +9684,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -9712,7 +9712,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -9734,7 +9734,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -11145,7 +11145,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -11170,7 +11170,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -11184,7 +11184,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -11210,7 +11210,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -11240,7 +11240,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -11267,7 +11267,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -11293,7 +11293,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -11312,7 +11312,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -12679,7 +12679,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -12704,7 +12704,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -12718,7 +12718,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -12744,7 +12744,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -12774,7 +12774,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -12801,7 +12801,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -12827,7 +12827,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -12846,7 +12846,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -14257,7 +14257,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -14282,7 +14282,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -14296,7 +14296,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -14322,7 +14322,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -14352,7 +14352,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -14379,7 +14379,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -14405,7 +14405,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -14433,7 +14433,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -14456,7 +14456,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -15823,7 +15823,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -15848,7 +15848,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -15862,7 +15862,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -15888,7 +15888,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -15918,7 +15918,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -15945,7 +15945,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -15971,7 +15971,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -15999,7 +15999,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -16022,7 +16022,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -17433,7 +17433,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -17458,7 +17458,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -17472,7 +17472,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -17504,7 +17504,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -17534,7 +17534,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -17552,7 +17552,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -18973,7 +18973,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -18998,7 +18998,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -19012,7 +19012,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -19044,7 +19044,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -19074,7 +19074,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -19092,7 +19092,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -20557,7 +20557,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -20582,7 +20582,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -20596,7 +20596,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -20628,7 +20628,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -20658,7 +20658,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -20686,7 +20686,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -20708,7 +20708,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -22129,7 +22129,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -22154,7 +22154,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -22168,7 +22168,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -22200,7 +22200,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -22230,7 +22230,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -22258,7 +22258,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -22280,7 +22280,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -23745,7 +23745,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -23770,7 +23770,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -23784,7 +23784,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -23816,7 +23816,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -23846,7 +23846,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -23873,7 +23873,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -23899,7 +23899,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -23918,7 +23918,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -25339,7 +25339,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -25364,7 +25364,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -25378,7 +25378,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -25410,7 +25410,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -25440,7 +25440,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -25467,7 +25467,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -25493,7 +25493,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -25512,7 +25512,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -26977,7 +26977,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -27002,7 +27002,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -27016,7 +27016,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -27048,7 +27048,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -27078,7 +27078,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -27105,7 +27105,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -27131,7 +27131,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -27159,7 +27159,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -27182,7 +27182,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -28603,7 +28603,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -28628,7 +28628,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -28642,7 +28642,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -28674,7 +28674,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -28704,7 +28704,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -28731,7 +28731,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -28757,7 +28757,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -28785,7 +28785,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -28808,7 +28808,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -37604,7 +37604,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -37629,7 +37629,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -37643,7 +37643,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -37669,7 +37669,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -37699,7 +37699,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -37717,7 +37717,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -39387,7 +39387,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -39412,7 +39412,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -39426,7 +39426,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -39452,7 +39452,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -39482,7 +39482,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -39500,7 +39500,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -41223,7 +41223,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -41248,7 +41248,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -41262,7 +41262,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -41288,7 +41288,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -41318,7 +41318,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -41346,7 +41346,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -41368,7 +41368,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -43038,7 +43038,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -43063,7 +43063,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -43077,7 +43077,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -43103,7 +43103,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -43133,7 +43133,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -43161,7 +43161,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -43183,7 +43183,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -44906,7 +44906,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -44931,7 +44931,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -44945,7 +44945,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -44971,7 +44971,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -45001,7 +45001,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -45028,7 +45028,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -45054,7 +45054,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -45073,7 +45073,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -46743,7 +46743,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -46768,7 +46768,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -46782,7 +46782,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -46808,7 +46808,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -46838,7 +46838,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -46865,7 +46865,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -46891,7 +46891,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -46910,7 +46910,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -48633,7 +48633,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -48658,7 +48658,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -48672,7 +48672,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -48698,7 +48698,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -48728,7 +48728,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -48755,7 +48755,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -48781,7 +48781,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -48809,7 +48809,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -48832,7 +48832,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -50502,7 +50502,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -50527,7 +50527,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -50541,7 +50541,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -50567,7 +50567,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -50597,7 +50597,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -50624,7 +50624,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -50650,7 +50650,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -50678,7 +50678,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -50701,7 +50701,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -52424,7 +52424,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -52449,7 +52449,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -52463,7 +52463,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -52489,7 +52489,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -52519,7 +52519,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -52537,7 +52537,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -54557,7 +54557,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -54582,7 +54582,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -54596,7 +54596,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -54622,7 +54622,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -54652,7 +54652,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -54670,7 +54670,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -56743,7 +56743,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -56768,7 +56768,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -56782,7 +56782,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -56808,7 +56808,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -56838,7 +56838,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -56866,7 +56866,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -56888,7 +56888,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -58908,7 +58908,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -58933,7 +58933,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -58947,7 +58947,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -58973,7 +58973,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -59003,7 +59003,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -59031,7 +59031,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -59053,7 +59053,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -61126,7 +61126,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -61151,7 +61151,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -61165,7 +61165,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -61191,7 +61191,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -61221,7 +61221,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -61248,7 +61248,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -61274,7 +61274,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -61293,7 +61293,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -63313,7 +63313,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -63338,7 +63338,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -63352,7 +63352,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -63378,7 +63378,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -63408,7 +63408,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -63435,7 +63435,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -63461,7 +63461,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -63480,7 +63480,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -65553,7 +65553,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -65578,7 +65578,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -65592,7 +65592,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -65618,7 +65618,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -65648,7 +65648,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -65675,7 +65675,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -65701,7 +65701,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -65729,7 +65729,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -65752,7 +65752,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -67772,7 +67772,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -67797,7 +67797,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -67811,7 +67811,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
         # ----------------------------------------------------------------------
         create_package:
           needs: package_coverage
@@ -67837,7 +67837,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -67867,7 +67867,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -67894,7 +67894,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -67920,7 +67920,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -67948,7 +67948,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -67971,7 +67971,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -70044,7 +70044,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -70069,7 +70069,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -70083,7 +70083,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -70115,7 +70115,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -70145,7 +70145,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -70163,7 +70163,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -71888,7 +71888,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -71913,7 +71913,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -71927,7 +71927,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -71959,7 +71959,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -71989,7 +71989,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -72007,7 +72007,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -73785,7 +73785,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -73810,7 +73810,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -73824,7 +73824,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -73856,7 +73856,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -73886,7 +73886,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -73914,7 +73914,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -73936,7 +73936,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -75661,7 +75661,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -75686,7 +75686,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -75700,7 +75700,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -75732,7 +75732,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -75762,7 +75762,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -75790,7 +75790,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -75812,7 +75812,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -77590,7 +77590,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -77615,7 +77615,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -77629,7 +77629,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -77661,7 +77661,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -77691,7 +77691,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -77718,7 +77718,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -77744,7 +77744,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -77763,7 +77763,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -79488,7 +79488,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -79513,7 +79513,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -79527,7 +79527,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -79559,7 +79559,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -79589,7 +79589,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -79616,7 +79616,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -79642,7 +79642,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -79661,7 +79661,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -81439,7 +81439,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -81464,7 +81464,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -81478,7 +81478,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -81510,7 +81510,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -81540,7 +81540,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -81567,7 +81567,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -81593,7 +81593,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -81621,7 +81621,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -81644,7 +81644,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -83369,7 +83369,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -83394,7 +83394,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -83408,7 +83408,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -83440,7 +83440,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -83470,7 +83470,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -83497,7 +83497,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -83523,7 +83523,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -83551,7 +83551,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -83574,7 +83574,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -85352,7 +85352,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -85377,7 +85377,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -85391,7 +85391,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -85423,7 +85423,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -85453,7 +85453,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -85471,7 +85471,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -87546,7 +87546,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -87571,7 +87571,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -87585,7 +87585,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -87617,7 +87617,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -87647,7 +87647,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -87665,7 +87665,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -89793,7 +89793,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -89818,7 +89818,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -89832,7 +89832,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -89864,7 +89864,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -89894,7 +89894,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -89922,7 +89922,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -89944,7 +89944,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -92019,7 +92019,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -92044,7 +92044,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -92058,7 +92058,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -92090,7 +92090,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -92120,7 +92120,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -92148,7 +92148,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -92170,7 +92170,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -94298,7 +94298,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -94323,7 +94323,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -94337,7 +94337,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -94369,7 +94369,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -94399,7 +94399,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -94426,7 +94426,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -94452,7 +94452,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -94471,7 +94471,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -96546,7 +96546,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -96571,7 +96571,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -96585,7 +96585,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -96617,7 +96617,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -96647,7 +96647,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -96674,7 +96674,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -96700,7 +96700,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -96719,7 +96719,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -98847,7 +98847,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -98872,7 +98872,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -98886,7 +98886,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -98918,7 +98918,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -98948,7 +98948,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -98975,7 +98975,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -99001,7 +99001,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -99029,7 +99029,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -99052,7 +99052,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:
@@ -101127,7 +101127,7 @@
         # ----------------------------------------------------------------------
         action_contexts:
           name: "Display GitHub Action Contexts"
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_display_action_contexts.yaml@CI-v0.23.0
       
         # ----------------------------------------------------------------------
         validate:
@@ -101152,7 +101152,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -101166,7 +101166,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_package_python_coverage.yaml@CI-v0.23.0
           with:
             gist_id: __simulated_gist_id__
             gist_filename: <<github_repo_name>>_coverage.json
@@ -101198,7 +101198,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -101228,7 +101228,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_package.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -101255,7 +101255,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -101281,7 +101281,7 @@
           permissions:
             contents: read
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_validate_python_binary.yaml@CI-v0.23.0
           with:
             operating_system: ${{ matrix.os }}
             python_version: ${{ matrix.python_version }}
@@ -101309,7 +101309,7 @@
             contents: read
             packages: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_create_docker_image.yaml@CI-v0.23.0
           with:
             operating_system: ubuntu-latest
             python_version: ${{ matrix.python_version }}
@@ -101332,7 +101332,7 @@
           permissions:
             contents: write
       
-          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.22.1
+          uses: davidbrownell/dbrownell_DevTools/.github/workflows/callable_publish_python.yaml@CI-v0.23.0
           with:
             release_sources_configuration_filename: .github/release_sources.yaml
           secrets:


### PR DESCRIPTION
## :pencil: Description
`actions/upload-artifact` introduced a breaking change on 9/2/24 (https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/). This change uses CI scripts that work around this breaking change.

Additional info: https://github.com/davidbrownell/dbrownell_DevTools/pull/91

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A