### PR TITLE
🐛 [-bug] Fix markdown rendering issue

### DIFF
--- a/template/__documentation/README.md
+++ b/template/__documentation/README.md
@@ -38,8 +38,6 @@ TODO: Complete this section
 ## Additional Information
 Additional information can be found at these locations.
 
-| Title | Document | Description |
-| --- | --- | --- |
 <!-- [BEGIN] Additional Information -->
 <!-- [END] Additional Information -->
 

--- a/template/__documentation/__postprocess.py
+++ b/template/__documentation/__postprocess.py
@@ -206,6 +206,8 @@ def UpdateReadmeFile():
         replacement_info["Development"] = "Please visit CONTRIBUTING.md and DEVELOPMENT.md for information on contributing to this project."
         replacement_info["Additional Information"] = textwrap.dedent(
             """\
+            | Title | Document | Description |
+            | --- | --- | --- |
             | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
             | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
             | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -219,6 +221,8 @@ def UpdateReadmeFile():
         replacement_info["Development"] = "Please visit [Contributing]({{ github_url }}/blob/main/CONTRIBUTING.md) and [Development]({{ github_url }}/blob/main/DEVELOPMENT.md) for information on contributing to this project."
         replacement_info["Additional Information"] = textwrap.dedent(
             """\
+            | Title | Document | Description |
+            | --- | --- | --- |
             | Code of Conduct | [CODE_OF_CONDUCT.md]({{ github_url }}/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
             | Contributing | [CONTRIBUTING.md]({{ github_url }}/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
             | Development | [DEVELOPMENT.md]({{ github_url }}/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |

--- a/tests/__snapshots__/All_EndToEndTest.ambr
+++ b/tests/__snapshots__/All_EndToEndTest.ambr
@@ -30289,9 +30289,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
       | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -30966,9 +30966,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
       | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -31781,9 +31781,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
       | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -32648,9 +32648,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
       | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -33354,9 +33354,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
       | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -34207,9 +34207,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | CODE_OF_CONDUCT.md | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | CONTRIBUTING.md | Information about contributing code changes to this project. |
       | Development | DEVELOPMENT.md | Information about development activities involved in making changes to this project. |
@@ -35184,9 +35184,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -35983,9 +35983,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -36941,9 +36941,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -38607,9 +38607,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -40424,9 +40424,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -42302,9 +42302,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -44151,9 +44151,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -46051,9 +46051,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -47922,9 +47922,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -49854,9 +49854,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -51757,9 +51757,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -53604,9 +53604,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -55771,9 +55771,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -57999,9 +57999,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -60198,9 +60198,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -62448,9 +62448,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -64669,9 +64669,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -66951,9 +66951,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -69204,9 +69204,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -71406,9 +71406,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -73284,9 +73284,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -75223,9 +75223,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -77133,9 +77133,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -79094,9 +79094,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -81026,9 +81026,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -83019,9 +83019,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -84983,9 +84983,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -86891,9 +86891,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -89119,9 +89119,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -91408,9 +91408,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -93668,9 +93668,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -95979,9 +95979,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -98261,9 +98261,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -100604,9 +100604,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |
@@ -102918,9 +102918,9 @@
       ## Additional Information
       Additional information can be found at these locations.
       
+      <!-- [BEGIN] Additional Information -->
       | Title | Document | Description |
       | --- | --- | --- |
-      <!-- [BEGIN] Additional Information -->
       | Code of Conduct | [CODE_OF_CONDUCT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CODE_OF_CONDUCT.md) | Information about the the norms, rules, and responsibilities we adhere to when participating in this open source community. |
       | Contributing | [CONTRIBUTING.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/CONTRIBUTING.md) | Information about contributing code changes to this project. |
       | Development | [DEVELOPMENT.md](https://github.com/<<github_username>>/<<github_repo_name>>/blob/main/DEVELOPMENT.md) | Information about development activities involved in making changes to this project. |


### PR DESCRIPTION
## :pencil: Description
With the previous change, comments delimiting sections dynamically populated are preserved to support better git diffs. However, this caused a regression in how markdown tables are rendered, as the HTML comments were embedded within the table, breaking GitHub's ability to render the markdown table. The fix is to move the delimiting comment outside of the table definition.

## :gear: Work Item
N/A

## :movie_camera: Demo
### Before
![image](https://github.com/user-attachments/assets/bf357cd2-db75-4f49-b0d3-9f63da236632)

### After
![image](https://github.com/user-attachments/assets/061f90cf-fcd6-48f3-a6e5-00ccb351bc9c)
